### PR TITLE
mgr/telemetry: update format_perf_histogram

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -111,6 +111,16 @@
 
   https://docs.ceph.com/en/latest/rados/operations/placement-groups/
 
+* telemetry: Improved the opt-in flow so that users can keep sharing the same
+  data, even when new data collections are available. A new 'perf' channel
+  that collects various performance metrics is now avaiable to opt-in to with:
+  `ceph telemetry on`
+  `ceph telemetry enable channel perf`
+  See a sample report with `ceph telemetry preview`
+  For more details, see:
+
+  https://docs.ceph.com/en/latest/mgr/telemetry/
+
 >=16.0.0
 --------
 * mgr/nfs: ``nfs`` module is moved out of volumes plugin. Prior using the

--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -178,29 +178,23 @@ List all collections with::
 
   ceph telemetry collection ls
 
-  NAME                  ENROLLED    STATUS    DEFAULT    DESC
-  basic_base            FALSE       OFF       ON         Basic information about the cluster (capacity, number and type of daemons, version, etc.)
-  basic_mds_metadata    FALSE       OFF       ON         MDS metadata
-  crash_base            FALSE       OFF       ON         Information about daemon crashes (daemon type and version, backtrace, etc.)
-  device_base           FALSE       OFF       ON         Information about device health metrics
-  ident_base            FALSE       OFF       OFF        User-provided identifying information about the cluster
-  perf_perf             FALSE       OFF       OFF        Information about performance of the cluster
+  NAME                  STATUS                                               DESC
+  basic_base            REPORTING                                            Basic information about the cluster (capacity, number and type of daemons, version, etc.)
+  basic_mds_metadata    NOT REPORTING: NOT OPTED-IN                          MDS metadata
+  crash_base            REPORTING                                            Information about daemon crashes (daemon type and version, backtrace, etc.)
+  device_base           REPORTING                                            Information about device health metrics
+  ident_base            NOT REPORTING: CHANNEL ident IS OFF                  User-provided identifying information about the cluster
+  perf_perf             NOT REPORTING: NOT OPTED-IN, CHANNEL perf IS OFF     Information about performance counters of the cluster
+
 
 Where:
 
 **NAME**: Collection name; prefix indicates the channel the collection belongs to.
 
-**ENROLLED**: Signifies the collections that were available in the module when
-the user last opted-in to telemetry. Please note: Even if a collection is
-'enrolled', its metrics will be reported only if its channel is enabled.
-The STATUS column indicates whether the collection is being reported.
-
 **STATUS**: Indicates whether the collection metrics are reported; this is
 determined by the status (enabled / disabled) of the channel the collection
-belongs to, along with the enrollment status of the collection.
-
-**DEFAULT**: The default status (enabled / disabled) of the channel the
-collection belongs to.
+belongs to, along with the enrollment status of the collection (whether the user
+is opted-in to this collection).
 
 **DESC**: General description of the collection.
 

--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -94,7 +94,7 @@ List all channels with::
   crash     ON         ON         Share metadata about Ceph daemon crashes (version, stack straces, etc)
   device    ON         ON         Share device health metrics (e.g., SMART data, minus potentially identifying info like serial numbers)
   ident     OFF        OFF        Share a user-provided description and/or contact email for the cluster
-  perf      ON         OFF        Share perf counter metrics summed across the whole cluster
+  perf      ON         OFF        Share various performance metrics of a cluster
 
 
 Enabling Telemetry
@@ -108,6 +108,9 @@ Please note: Telemetry data is licensed under the Community Data License
 Agreement - Sharing - Version 1.0 (https://cdla.io/sharing-1-0/). Hence,
 telemetry module can be enabled only after you add '--license sharing-1-0' to
 the 'ceph telemetry on' command.
+Once telemetry is on, please consider enabling channels which are off by
+default, such as the 'perf' channel. 'ceph telemetry on' output will list the
+exact command to enable these channels.
 
 Telemetry can be disabled at any time with::
 
@@ -124,6 +127,9 @@ If telemetry is off, you can preview a sample report with::
 
   ceph telemetry preview
 
+Generating a sample report might take a few moments in big clusters (clusters
+with hundreds of OSDs or more).
+
 To protect your privacy, device reports are generated separately, and data such
 as hostname and device serial number is anonymized. The device telemetry is
 sent to a different endpoint and does not associate the device data with a
@@ -131,7 +137,7 @@ particular cluster. To see a preview of the device report use the command::
 
   ceph telemetry show-device
 
-If telemetry is off you can preview a sample device report with::
+If telemetry is off, you can preview a sample device report with::
 
   ceph telemetry preview-device
 
@@ -144,7 +150,7 @@ In case you prefer to have a single output of both reports, and telemetry is on,
 
   ceph telemetry show-all
 
-Otherwise use::
+If you would like to view a single output of both reports, and telemetry is off, use::
 
   ceph telemetry preview-all
 
@@ -166,7 +172,7 @@ If telemetry is off you can preview a sample report by channel with::
 Collections
 -----------
 
-Collections represent what we collect by channel.
+Collections represent different aspects of data that we collect within a channel.
 
 List all collections with::
 
@@ -178,7 +184,7 @@ List all collections with::
   crash_base            FALSE       OFF       ON         Information about daemon crashes (daemon type and version, backtrace, etc.)
   device_base           FALSE       OFF       ON         Information about device health metrics
   ident_base            FALSE       OFF       OFF        User-provided identifying information about the cluster
-  perf_perf             FALSE       OFF       OFF        Information about performance counters of the cluster
+  perf_perf             FALSE       OFF       OFF        Information about performance of the cluster
 
 Where:
 
@@ -187,6 +193,7 @@ Where:
 **ENROLLED**: Signifies the collections that were available in the module when
 the user last opted-in to telemetry. Please note: Even if a collection is
 'enrolled', its metrics will be reported only if its channel is enabled.
+The STATUS column indicates whether the collection is being reported.
 
 **STATUS**: Indicates whether the collection metrics are reported; this is
 determined by the status (enabled / disabled) of the channel the collection

--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -83,6 +83,11 @@ Multiple channels can be enabled or disabled with::
   ceph telemetry enable channel basic crash device ident perf
   ceph telemetry disable channel basic crash device ident perf
 
+Channels can be enabled or disabled all at once with::
+
+  ceph telemetry enable channel all
+  ceph telemetry disable channel all
+
 Please note that telemetry should be on for these commands to take effect.
 
 List all channels with::

--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -64,37 +64,38 @@ the way Ceph is used.
 
 Data is sent secured to *https://telemetry.ceph.com*.
 
-Sample report
--------------
-
-You can look at what data is reported at any time with the command::
-
-  ceph telemetry show
-
-To protect your privacy, device reports are generated separately, and data such
-as hostname and device serial number is anonymized. The device telemetry is
-sent to a different endpoint and does not associate the device data with a
-particular cluster. To see a preview of the device report use the command::
-
-  ceph telemetry show-device
-
-Please note: In order to generate the device report we use Smartmontools
-version 7.0 and up, which supports JSON output. 
-If you have any concerns about privacy with regard to the information included in
-this report, please contact the Ceph developers.
-
-Channels
---------
-
 Individual channels can be enabled or disabled with::
 
-  ceph config set mgr mgr/telemetry/channel_ident false
-  ceph config set mgr mgr/telemetry/channel_basic false
-  ceph config set mgr mgr/telemetry/channel_crash false
-  ceph config set mgr mgr/telemetry/channel_device false
-  ceph config set mgr mgr/telemetry/channel_perf false
-  ceph telemetry show
-  ceph telemetry show-device
+  ceph telemetry enable channel basic
+  ceph telemetry enable channel crash
+  ceph telemetry enable channel device
+  ceph telemetry enable channel ident
+  ceph telemetry enable channel perf
+
+  ceph telemetry disable channel basic
+  ceph telemetry disable channel crash
+  ceph telemetry disable channel device
+  ceph telemetry disable channel ident
+  ceph telemetry disable channel perf
+
+Multiple channels can be enabled or disabled with::
+
+  ceph telemetry enable channel basic crash device ident perf
+  ceph telemetry disable channel basic crash device ident perf
+
+Please note that telemetry should be on for these commands to take effect.
+
+List all channels with::
+
+  ceph telemetry channel ls
+
+  NAME      ENABLED    DEFAULT    DESC
+  basic     ON         ON         Share basic cluster information (size, version)
+  crash     ON         ON         Share metadata about Ceph daemon crashes (version, stack straces, etc)
+  device    ON         ON         Share device health metrics (e.g., SMART data, minus potentially identifying info like serial numbers)
+  ident     OFF        OFF        Share a user-provided description and/or contact email for the cluster
+  perf      ON         OFF        Share perf counter metrics summed across the whole cluster
+
 
 Enabling Telemetry
 ------------------
@@ -111,6 +112,103 @@ the 'ceph telemetry on' command.
 Telemetry can be disabled at any time with::
 
   ceph telemetry off
+
+Sample report
+-------------
+
+You can look at what data is reported at any time with the command::
+
+  ceph telemetry show
+
+If telemetry is off, you can preview a sample report with::
+
+  ceph telemetry preview
+
+To protect your privacy, device reports are generated separately, and data such
+as hostname and device serial number is anonymized. The device telemetry is
+sent to a different endpoint and does not associate the device data with a
+particular cluster. To see a preview of the device report use the command::
+
+  ceph telemetry show-device
+
+If telemetry is off you can preview a sample device report with::
+
+  ceph telemetry preview-device
+
+Please note: In order to generate the device report we use Smartmontools
+version 7.0 and up, which supports JSON output. 
+If you have any concerns about privacy with regard to the information included in
+this report, please contact the Ceph developers.
+
+In case you prefer to have a single output of both reports, and telemetry is on, use::
+
+  ceph telemetry show-all
+
+Otherwise use::
+
+  ceph telemetry preview-all
+
+**Sample report by channel**
+
+When telemetry is on you can see what data is reported by channel with::
+
+  ceph telemetry show <channel_name>
+
+Please note: If telemetry is on, and <channel_name> is disabled, the command
+above will output a sample report by that channel, according to the collections
+the user is enrolled to. However this data is not reported, since the channel
+is disabled.
+
+If telemetry is off you can preview a sample report by channel with::
+
+  ceph telemetry preview <channel_name>
+
+Collections
+-----------
+
+Collections represent what we collect by channel.
+
+List all collections with::
+
+  ceph telemetry collection ls
+
+  NAME                  ENROLLED    STATUS    DEFAULT    DESC
+  basic_base            FALSE       OFF       ON         Basic information about the cluster (capacity, number and type of daemons, version, etc.)
+  basic_mds_metadata    FALSE       OFF       ON         MDS metadata
+  crash_base            FALSE       OFF       ON         Information about daemon crashes (daemon type and version, backtrace, etc.)
+  device_base           FALSE       OFF       ON         Information about device health metrics
+  ident_base            FALSE       OFF       OFF        User-provided identifying information about the cluster
+  perf_perf             FALSE       OFF       OFF        Information about performance counters of the cluster
+
+Where:
+
+**NAME**: Collection name; prefix indicates the channel the collection belongs to.
+
+**ENROLLED**: Signifies the collections that were available in the module when
+the user last opted-in to telemetry. Please note: Even if a collection is
+'enrolled', its metrics will be reported only if its channel is enabled.
+
+**STATUS**: Indicates whether the collection metrics are reported; this is
+determined by the status (enabled / disabled) of the channel the collection
+belongs to, along with the enrollment status of the collection.
+
+**DEFAULT**: The default status (enabled / disabled) of the channel the
+collection belongs to.
+
+**DESC**: General description of the collection.
+
+See the diff between the collections you are enrolled to, and the new,
+available collections with::
+
+  ceph telemetry diff
+
+Enroll to the most recent collections with::
+
+  ceph telemetry on
+
+Then enable new channels that are off with::
+
+  ceph telemetry enable channel <channel_name>
 
 Interval
 --------

--- a/src/pybind/mgr/dashboard/controllers/telemetry.py
+++ b/src/pybind/mgr/dashboard/controllers/telemetry.py
@@ -213,7 +213,7 @@ class Telemetry(RESTController):
         :return: Ceph and device report data
         :rtype: dict
         """
-        return mgr.remote('telemetry', 'get_report', 'all')
+        return mgr.remote('telemetry', 'get_report_locked', 'all')
 
     def singleton_set(self, enable=True, license_name=None):
         """

--- a/src/pybind/mgr/telemetry/__init__.py
+++ b/src/pybind/mgr/telemetry/__init__.py
@@ -1,1 +1,9 @@
-from .module import Module
+import os
+
+if 'UNITTEST' in os.environ:
+    import tests
+
+try:
+    from .module import Module
+except ImportError:
+    pass

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -169,7 +169,7 @@ class Module(MgrModule):
         Option(name='channel_perf',
                type='bool',
                default=False,
-               desc='Share perf counter metrics summed across the whole cluster'),
+               desc='Share various performance metrics of a cluster'),
     ]
 
     @property

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -66,7 +66,7 @@ class Collection(str, enum.Enum):
     perf_perf = 'perf_perf'
     basic_mds_metadata = 'basic_mds_metadata'
 
-MODULE_COLLECTION = [
+MODULE_COLLECTION : List[Dict] = [
     {
         "name": Collection.basic_base,
         "description": "Basic information about the cluster (capacity, number and type of daemons, version, etc.)",
@@ -180,9 +180,9 @@ class Module(MgrModule):
         super(Module, self).__init__(*args, **kwargs)
         self.event = Event()
         self.run = False
-        self.db_collection: List[str] = None
-        self.last_opted_in_ceph_version: int = None
-        self.last_opted_out_ceph_version: int = None
+        self.db_collection: Optional[List[str]] = None
+        self.last_opted_in_ceph_version: Optional[int] = None
+        self.last_opted_out_ceph_version: Optional[int] = None
         self.last_upload: Optional[int] = None
         self.last_report: Dict[str, Any] = dict()
         self.report_id: Optional[str] = None
@@ -998,12 +998,11 @@ class Module(MgrModule):
             report['fs']['total_num_mds'] = num_mds  # type: ignore
 
             # daemons
-            report['metadata'] = dict()
-            report['metadata']['osd'] = self.gather_osd_metadata(osd_map)
-            report['metadata']['mon'] = self.gather_mon_metadata(mon_map)
+            report['metadata'] = dict(osd=self.gather_osd_metadata(osd_map),
+                                      mon=self.gather_mon_metadata(mon_map))
 
             if self.is_enabled_collection(Collection.basic_mds_metadata):
-                report['metadata']['mds'] = self.gather_mds_metadata()
+                report['metadata']['mds'] = self.gather_mds_metadata()  # type: ignore
 
             # host counts
             servers = self.list_servers()
@@ -1107,16 +1106,19 @@ class Module(MgrModule):
         ceph = 'ceph'
         device = 'device'
 
-    def collection_delta(self, channels: Optional[List[str]] = None) -> List[Collection]:
+    def collection_delta(self, channels: Optional[List[str]] = None) -> Optional[List[Collection]]:
         '''
         Find collections that are available in the module, but are not in the db
         '''
+        if self.db_collection is None:
+            return None
+
         if not channels:
             channels = ALL_CHANNELS
         else:
-            for c in channels:
-                if c not in ALL_CHANNELS:
-                    self.log.debug(f"invalid channel name: {c}")
+            for ch in channels:
+                if ch not in ALL_CHANNELS:
+                    self.log.debug(f"invalid channel name: {ch}")
                     return None
 
         new_collection : List[Collection] = []
@@ -1152,6 +1154,8 @@ class Module(MgrModule):
         # opted-in, or invoked `telemetry off`), or they upgraded from a
         # telemetry revision 1 or 2, which required to re-opt in to revision 3,
         # regardless, hence is considered as opted-out
+        if self.db_collection is None:
+            return False
         return len(self.db_collection) > 0
 
     def should_nag(self) -> bool:
@@ -1167,12 +1171,13 @@ class Module(MgrModule):
 
         # check if there are collections the user is not opt-in to
         # that we should nag about
-        for c in MODULE_COLLECTION:
-            for k, v in c.items():
-                if k == 'name' and v.name not in self.db_collection:
-                    if c['nag'] == True:
-                        self.log.debug(f"The collection: {v} is not reported, and we should nag about it")
-                        return True
+        if self.db_collection is not None:
+            for c in MODULE_COLLECTION:
+                for k, v in c.items():
+                    if k == 'name' and v.name not in self.db_collection:
+                        if c['nag'] == True:
+                            self.log.debug(f"The collection: {v} is not reported, and we should nag about it")
+                            return True
 
         # user might be opted-in to the most recent collection, or there is no
         # new collection which requires nagging about
@@ -1208,18 +1213,26 @@ class Module(MgrModule):
 
             # reload collection after setting
             collection = self.get_store('collection')
-            self.db_collection = json.loads(collection)
+            if collection is not None:
+                self.db_collection = json.loads(collection)
+            else:
+                raise RuntimeError('collection is None after initial setting')
         else:
             # user has already upgraded
             self.log.debug(f"user has upgraded already: collection: {self.db_collection}")
 
     def is_enabled_collection(self, collection: Collection) -> bool:
+        if self.db_collection is None:
+            return False
         return collection.name in self.db_collection
 
     def opt_in_all_collections(self) -> None:
         """
         Opt-in to all collections; Update db with the currently available collections in the module
         """
+        if self.db_collection is None:
+            raise RuntimeError('db_collection is None after initial setting')
+
         for c in MODULE_COLLECTION:
             for k, v in c.items():
                 if k == 'name' and v.name not in self.db_collection:
@@ -1270,7 +1283,7 @@ class Module(MgrModule):
             return 1, '', '\n'.join(success + failed)
         return 0, '', '\n'.join(success)
 
-    def format_perf_histogram(self, report):
+    def format_perf_histogram(self, report: Dict[str, Any]) -> None:
         # Formatting the perf histograms so they are human-readable. This will change the
         # ranges and values, which are currently in list form, into strings so that
         # they are displayed horizontally instead of vertically.
@@ -1299,7 +1312,7 @@ class Module(MgrModule):
             # histograms.
             pass
 
-    def toggle_channel(self, action, channels: Optional[List[str]] = None) -> Tuple[int, str, str]:
+    def toggle_channel(self, action: str, channels: Optional[List[str]] = None) -> Tuple[int, str, str]:
         '''
         Enable or disable a list of channels
         '''
@@ -1328,7 +1341,7 @@ class Module(MgrModule):
 
         return 0, msg, ''
 
-    def restore_default_opt_setting(self, opt_name) -> None:
+    def restore_default_opt_setting(self, opt_name: str) -> None:
         for o in self.MODULE_OPTIONS:
             if o['name'] == opt_name:
                 default_val = o.get('default', None)
@@ -1360,7 +1373,7 @@ class Module(MgrModule):
         for c in MODULE_COLLECTION:
             for k, v in c.items():
                 if k == 'name':
-                    if not self.is_enabled_collection(v):
+                    if not self.is_enabled_collection(Collection(v)):
                         diff.append({key: val for key, val in c.items() if key not in keys})
 
         r = None
@@ -1528,8 +1541,9 @@ Please consider enabling the telemetry module with 'ceph telemetry on'.'''
         # the report, and at the same time the module hits the interval of
         # sending a report with the opted-in collection, which has less data
         # than in the preview report.
+        col_delta = self.collection_delta()
         with self.get_report_lock:
-            if len(self.collection_delta()) == 0:
+            if col_delta is not None and len(col_delta) == 0:
                 # user is already opted-in to the most recent collection
                 msg = 'Telemetry is up to date, see report with `ceph telemetry show`.'
                 return 0, msg, ''
@@ -1581,8 +1595,9 @@ Please consider enabling the telemetry module with 'ceph telemetry on'.'''
         '''
         report = {}
 
+        device_col_delta = self.collection_delta(['device'])
         with self.get_report_lock:
-            if len(self.collection_delta(['device'])) == 0 and self.channel_device:
+            if device_col_delta is not None and len(device_col_delta) == 0 and self.channel_device:
                 # user is already opted-in to the most recent device collection,
                 # and device channel is on, thus `show-device` should be called
                 msg = 'device channel is on and up to date, see report with `ceph telemetry show-device`.'
@@ -1599,9 +1614,10 @@ Please consider enabling the telemetry module with 'ceph telemetry on'.'''
 
             opted_in_collection = self.db_collection
             self.db_collection = next_collection
-            report = json.dumps(self.get_report('device'), indent=4, sort_keys=True)
+            report = self.get_report('device')
             self.db_collection = opted_in_collection
 
+        report = json.dumps(report, indent=4, sort_keys=True)
         return 0, report, ''
 
     @CLIReadCommand('telemetry show-all')
@@ -1629,8 +1645,9 @@ Please consider enabling the telemetry module with 'ceph telemetry on'.'''
         '''
         report = {}
 
+        col_delta = self.collection_delta()
         with self.get_report_lock:
-            if len(self.collection_delta()) == 0:
+            if col_delta is not None and len(col_delta) == 0:
                 # user is already opted-in to the most recent collection
                 msg = 'Telemetry is up to date, see report with `ceph telemetry show`.'
                 return 0, msg, ''
@@ -1729,11 +1746,9 @@ Please consider enabling the telemetry module with 'ceph telemetry on'.'''
                 try:
                     self.last_report = self.compile_report()
                 except Exception:
-                    # TODO add the exception here
                     self.log.exception('Exception while compiling report:')
 
                 self.send(self.last_report)
-                self.log.debug("SENDING REPORT")
             else:
                 self.log.debug('Interval for sending new report has not expired')
 

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -1491,7 +1491,48 @@ To enable, add '--license {LICENSE}' to the 'ceph telemetry on' command.'''
                 desc,
             ))
 
-        return 0, table.get_string(), ''
+        return 0, table.get_string(sortby="NAME"), ''
+
+    @CLIReadCommand('telemetry collection ls')
+    def collection_ls(self) -> Tuple[int, str, str]:
+        '''
+        List all collections
+        '''
+        table = PrettyTable(
+            [
+                'NAME', 'ENROLLED', 'STATUS', 'DEFAULT', 'DESC',
+            ],
+            border=False)
+        table.align['NAME'] = 'l'
+        table.align['ENROLLED'] = 'l'
+        table.align['STATUS'] = 'l'
+        table.align['DEFAULT'] = 'l'
+        table.align['DESC'] = 'l'
+        table.left_padding_width = 0
+        table.right_padding_width = 4
+
+        for c in MODULE_COLLECTION:
+            name = c['name']
+            enrolled = "TRUE" if self.is_enabled_collection(name) else "FALSE"
+            status = "ON" if getattr(self, f"channel_{c['channel']}") and self.is_enabled_collection(name) \
+                    else "OFF"
+            # default value of *channel*, since we check for active channels
+            # when generating reports
+            for o in self.MODULE_OPTIONS:
+                if o['name'] == f"channel_{c['channel']}":
+                    default = "ON" if o.get('default', None) else "OFF"
+
+            desc = c['description']
+
+            table.add_row((
+                name,
+                enrolled,
+                status,
+                default,
+                desc,
+            ))
+
+        return 0, table.get_string(sortby="NAME"), ''
 
     @CLICommand('telemetry send')
     def do_send(self,

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -1107,16 +1107,25 @@ class Module(MgrModule):
         ceph = 'ceph'
         device = 'device'
 
-    def collection_delta(self) -> List[Collection]:
+    def collection_delta(self, channels: Optional[List[str]] = None) -> List[Collection]:
         '''
         Find collections that are available in the module, but are not in the db
         '''
+        if not channels:
+            channels = ALL_CHANNELS
+        else:
+            for c in channels:
+                if c not in ALL_CHANNELS:
+                    self.log.debug(f"invalid channel name: {c}")
+                    return None
+
         new_collection : List[Collection] = []
 
         for c in MODULE_COLLECTION:
             for k, v in c.items():
                 if k == 'name' and v.name not in self.db_collection:
-                    new_collection.append(v)
+                    if c['channel'] in channels:
+                        new_collection.append(v)
 
         return new_collection
 
@@ -1475,6 +1484,9 @@ To enable, add '--license {LICENSE}' to the 'ceph telemetry on' command.'''
     def do_send(self,
                 endpoint: Optional[List[EndPoint]] = None,
                 license: Optional[str] = None) -> Tuple[int, str, str]:
+        '''
+        Send a sample report
+        '''
         if not self.is_opted_in() and license != LICENSE:
             self.log.debug(('A telemetry send attempt while opted-out. '
                             'Asking for license agreement'))
@@ -1488,7 +1500,7 @@ Please consider enabling the telemetry module with 'ceph telemetry on'.'''
     @CLIReadCommand('telemetry show')
     def show(self, channels: Optional[List[str]] = None) -> Tuple[int, str, str]:
         '''
-        Show a sample report of all enabled channels (except for 'device' channel)
+        Show a sample report of opted-in collections (except for 'device')
         '''
         if not self.enabled:
             # if telemetry is off, no report is being sent, hence nothing to show
@@ -1508,7 +1520,7 @@ Please consider enabling the telemetry module with 'ceph telemetry on'.'''
     @CLIReadCommand('telemetry preview')
     def preview(self, channels: Optional[List[str]] = None) -> Tuple[int, str, str]:
         '''
-        Preview a sample report of the most recent collections available
+        Preview a sample report of the most recent collections available (except for 'device')
         '''
         report = {}
 
@@ -1519,7 +1531,7 @@ Please consider enabling the telemetry module with 'ceph telemetry on'.'''
         with self.get_report_lock:
             if len(self.collection_delta()) == 0:
                 # user is already opted-in to the most recent collection
-                msg = 'Telemetry is up to date, see report with `ceph telemetry show`'
+                msg = 'Telemetry is up to date, see report with `ceph telemetry show`.'
                 return 0, msg, ''
             else:
                 # there are collections the user is not opted-in to
@@ -1537,19 +1549,109 @@ Please consider enabling the telemetry module with 'ceph telemetry on'.'''
 
         self.format_perf_histogram(report)
         report = json.dumps(report, indent=4, sort_keys=True)
-        if self.channel_device:
-            report += '''
 
-Device report is generated separately. To see it run 'ceph telemetry show-device'.'''
+        if self.channel_device:
+            report += '''\nDevice report is generated separately. To see it run 'ceph telemetry preview-device'.'''
+
         return 0, report, ''
 
     @CLIReadCommand('telemetry show-device')
     def show_device(self) -> Tuple[int, str, str]:
+        '''
+        Show a sample device report
+        '''
+        if not self.enabled:
+            # if telemetry is off, no report is being sent, hence nothing to show
+            msg = 'Telemetry is off. Please consider opting-in with `ceph telemetry on`.\n' \
+                  'Preview sample device reports with `ceph telemetry preview-device`.'
+            return 0, msg, ''
+
+        if not self.channel_device:
+            # if device channel is off, device report is not being sent, hence nothing to show
+            msg = 'device channel is off. Please enable with `ceph telemetry enable channel device`.\n' \
+                  'Preview sample device reports with `ceph telemetry preview-device`.'
+            return 0, msg, ''
+
         return 0, json.dumps(self.get_report_locked('device'), indent=4, sort_keys=True), ''
+
+    @CLIReadCommand('telemetry preview-device')
+    def preview_device(self) -> Tuple[int, str, str]:
+        '''
+        Preview a sample device report of the most recent device collection
+        '''
+        report = {}
+
+        with self.get_report_lock:
+            if len(self.collection_delta(['device'])) == 0 and self.channel_device:
+                # user is already opted-in to the most recent device collection,
+                # and device channel is on, thus `show-device` should be called
+                msg = 'device channel is on and up to date, see report with `ceph telemetry show-device`.'
+                return 0, msg, ''
+
+            # either the user is not opted-in at all, or there are collections
+            # they are not opted-in to
+            next_collection = []
+
+            for c in MODULE_COLLECTION:
+                for k, v in c.items():
+                    if k == 'name':
+                        next_collection.append(v.name)
+
+            opted_in_collection = self.db_collection
+            self.db_collection = next_collection
+            report = json.dumps(self.get_report('device'), indent=4, sort_keys=True)
+            self.db_collection = opted_in_collection
+
+        return 0, report, ''
 
     @CLIReadCommand('telemetry show-all')
     def show_all(self) -> Tuple[int, str, str]:
+        '''
+        Show a sample report of all enabled channels (including 'device' channel)
+        '''
+        if not self.enabled:
+            # if telemetry is off, no report is being sent, hence nothing to show
+            msg = 'Telemetry is off. Please consider opting-in with `ceph telemetry on`.\n' \
+                  'Preview sample reports with `ceph telemetry preview`.'
+            return 0, msg, ''
+
+        if not self.channel_device:
+            # device channel is off, no need to display its report
+            return 0, json.dumps(self.get_report_locked('default'), indent=4, sort_keys=True), ''
+
+        # telemetry is on and device channel is enabled, show both
         return 0, json.dumps(self.get_report_locked('all'), indent=4, sort_keys=True), ''
+
+    @CLIReadCommand('telemetry preview-all')
+    def preview_all(self) -> Tuple[int, str, str]:
+        '''
+        Preview a sample report of the most recent collections available of all channels (including 'device')
+        '''
+        report = {}
+
+        with self.get_report_lock:
+            if len(self.collection_delta()) == 0:
+                # user is already opted-in to the most recent collection
+                msg = 'Telemetry is up to date, see report with `ceph telemetry show`.'
+                return 0, msg, ''
+
+            # there are collections the user is not opted-in to
+            next_collection = []
+
+            for c in MODULE_COLLECTION:
+                for k, v in c.items():
+                    if k == 'name':
+                        next_collection.append(v.name)
+
+            opted_in_collection = self.db_collection
+            self.db_collection = next_collection
+            report = self.get_report('all')
+            self.db_collection = opted_in_collection
+
+        self.format_perf_histogram(report)
+        report = json.dumps(report, indent=4, sort_keys=True)
+
+        return 0, report, ''
 
     def get_report_locked(self,
                           report_type: str = 'default',

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -15,7 +15,7 @@ import requests
 import uuid
 import time
 from datetime import datetime, timedelta
-from threading import Event
+from threading import Event, Lock
 from collections import defaultdict
 from typing import cast, Any, DefaultDict, Dict, List, Optional, Tuple, TypeVar, TYPE_CHECKING, Union
 
@@ -27,11 +27,6 @@ ALL_CHANNELS = ['basic', 'ident', 'crash', 'device', 'perf']
 LICENSE = 'sharing-1-0'
 LICENSE_NAME = 'Community Data License Agreement - Sharing - Version 1.0'
 LICENSE_URL = 'https://cdla.io/sharing-1-0/'
-
-# If the telemetry revision has changed since this point, re-require
-# an opt-in.  This should happen each time we add new information to
-# the telemetry report.
-LAST_REVISION_RE_OPT_IN = 2
 
 # Latest revision of the telemetry report.  Bump this each time we make
 # *any* change.
@@ -61,6 +56,53 @@ REVISION = 3
 #   - rbd pool and image count, and rbd mirror mode (pool-level)
 #   - rgw daemons, zones, zonegroups; which rgw frontends
 #   - crush map stats
+
+class Collection(str, enum.Enum):
+    legacy_basic = 'legacy_basic'
+    legacy_device = 'legacy_device'
+    legacy_crash = 'legacy_crash'
+    legacy_ident = 'legacy_ident'
+    perf = 'perf'
+    mds_metadata = 'mds_metadata'
+
+MODULE_COLLECTION = [
+    {
+        "name": Collection.legacy_basic,
+        "description": "Basic information about the cluster (capacity, number and type of daemons, version, etc.)",
+        "channel": "basic",
+        "nag": False
+    },
+    {
+        "name": Collection.legacy_device, 
+        "description": "Information about device health metrics",
+        "channel": "device",
+        "nag": False
+    },
+    {
+        "name": Collection.legacy_crash,
+        "description": "Information about daemon crashes (daemon type and version, backtrace, etc.)",
+        "channel": "crash",
+        "nag": False
+    },
+    {
+        "name": Collection.legacy_ident,
+        "description": "User-provided identifying information about the cluster",
+        "channel": "ident",
+        "nag": False
+    },
+    {
+        "name": Collection.perf,
+        "description": "Information about performance counters of the cluster",
+        "channel": "perf",
+        "nag": True
+    },
+    {
+        "name": Collection.mds_metadata,
+        "description": "MDS metadata",
+        "channel": "basic",
+        "nag": False
+    }
+]
 
 class Module(MgrModule):
     metadata_keys = [
@@ -137,10 +179,14 @@ class Module(MgrModule):
         super(Module, self).__init__(*args, **kwargs)
         self.event = Event()
         self.run = False
+        self.db_collection: List[str] = None
+        self.last_opted_in_ceph_version: int = None
+        self.last_opted_out_ceph_version: int = None
         self.last_upload: Optional[int] = None
         self.last_report: Dict[str, Any] = dict()
         self.report_id: Optional[str] = None
         self.salt: Optional[str] = None
+        self.get_report_lock = Lock()
         self.config_update_module_option()
         # for mypy which does not run the code
         if TYPE_CHECKING:
@@ -156,6 +202,9 @@ class Module(MgrModule):
             self.channel_crash = True
             self.channel_device = True
             self.channel_perf = False
+            self.db_collection = ['legacy_basic', 'legacy_device']
+            self.last_opted_in_ceph_version = 17
+            self.last_opted_out_ceph_version = 0
 
     def config_update_module_option(self) -> None:
         for opt in self.MODULE_OPTIONS:
@@ -189,6 +238,20 @@ class Module(MgrModule):
             self.set_store('salt', self.salt)
         else:
             self.salt = salt
+
+        self.init_collection()
+
+        last_opted_in_ceph_version = self.get_store('last_opted_in_ceph_version', None)
+        if last_opted_in_ceph_version is None:
+            self.last_opted_in_ceph_version = None
+        else:
+            self.last_opted_in_ceph_version = int(last_opted_in_ceph_version)
+
+        last_opted_out_ceph_version = self.get_store('last_opted_out_ceph_version', None)
+        if last_opted_out_ceph_version is None:
+            self.last_opted_out_ceph_version = None
+        else:
+            self.last_opted_out_ceph_version = int(last_opted_out_ceph_version)
 
     def gather_osd_metadata(self,
                             osd_map: Dict[str, List[Dict[str, int]]]) -> Dict[str, Dict[str, int]]:
@@ -227,6 +290,29 @@ class Module(MgrModule):
                 self.log.debug('Could not get metadata for mon.%s' % (mon['name']))
                 continue
             for k, v in res.items():
+                if k not in keys:
+                    continue
+
+                metadata[k][v] += 1
+
+        return metadata
+
+    def gather_mds_metadata(self) -> Dict[str, Dict[str, int]]:
+        metadata: Dict[str, Dict[str, int]] = dict()
+
+        res = self.get('mds_metadata') # metadata of *all* mds daemons
+        if res is None or not res:
+            self.log.debug('Could not get metadata for mds daemons')
+            return metadata
+
+        keys = list()
+        keys += self.metadata_keys
+
+        for key in keys:
+            metadata[key] = defaultdict(int)
+
+        for mds in res.values():
+            for k, v in mds.items():
                 if k not in keys:
                     continue
 
@@ -911,8 +997,12 @@ class Module(MgrModule):
             report['fs']['total_num_mds'] = num_mds  # type: ignore
 
             # daemons
-            report['metadata'] = dict(osd=self.gather_osd_metadata(osd_map),
-                                      mon=self.gather_mon_metadata(mon_map))
+            report['metadata'] = dict()
+            report['metadata']['osd'] = self.gather_osd_metadata(osd_map)
+            report['metadata']['mon'] = self.gather_mon_metadata(mon_map)
+
+            if self.is_enabled_collection(Collection.mds_metadata):
+                report['metadata']['mds'] = self.gather_mds_metadata()
 
             # host counts
             servers = self.list_servers()
@@ -981,14 +1071,15 @@ class Module(MgrModule):
             report['crashes'] = self.gather_crashinfo()
 
         if 'perf' in channels:
-            report['perf_counters'] = self.gather_perf_counters('separated')
-            report['stats_per_pool'] = self.get_stats_per_pool()
-            report['stats_per_pg'] = self.get_stats_per_pg()
-            report['io_rate'] = self.get_io_rate()
-            report['osd_perf_histograms'] = self.get_osd_histograms('separated')
-            report['mempool'] = self.get_mempool('separated')
-            report['heap_stats'] = self.get_heap_stats()
-            report['rocksdb_stats'] = self.get_rocksdb_stats()
+            if self.is_enabled_collection(Collection.perf):
+                report['perf_counters'] = self.gather_perf_counters('separated')
+                report['stats_per_pool'] = self.get_stats_per_pool()
+                report['stats_per_pg'] = self.get_stats_per_pg()
+                report['io_rate'] = self.get_io_rate()
+                report['osd_perf_histograms'] = self.get_osd_histograms('separated')
+                report['mempool'] = self.get_mempool('separated')
+                report['heap_stats'] = self.get_heap_stats()
+                report['rocksdb_stats'] = self.get_rocksdb_stats()
 
         # NOTE: We do not include the 'device' channel in this report; it is
         # sent to a different endpoint.
@@ -1014,6 +1105,117 @@ class Module(MgrModule):
     class EndPoint(enum.Enum):
         ceph = 'ceph'
         device = 'device'
+
+    def collection_delta(self) -> List[Collection]:
+        '''
+        Find collections that are available in the module, but are not in the db
+        '''
+        new_collection : List[Collection] = []
+
+        for c in MODULE_COLLECTION:
+            for k, v in c.items():
+                if k == 'name' and v.name not in self.db_collection:
+                    new_collection.append(v)
+
+        return new_collection
+    
+    def is_major_upgrade(self) -> bool:
+        '''
+        Returns True only if the user last opted-in to an older major
+        '''
+        if self.last_opted_in_ceph_version is None or self.last_opted_in_ceph_version == 0:
+            # we do not know what Ceph version was when the user last opted-in,
+            # thus we do not wish to nag in case of a major upgrade
+            return False
+
+        mon_map = self.get('mon_map')
+        mon_min = mon_map.get("min_mon_release", 0)
+
+        if mon_min - self.last_opted_in_ceph_version > 0:
+            self.log.debug(f"major upgrade: mon_min is is: {mon_min} and user last opted-in in {self.last_opted_in_ceph_version}")
+            return True
+
+        return False
+
+    def is_opted_in(self) -> bool:
+        # If len is 0 it means that the user is either opted-out (never
+        # opted-in, or invoked `telemetry off`), or they upgraded from a
+        # telemetry revision 1 or 2, which required to re-opt in to revision 3,
+        # regardless, hence is considered as opted-out
+        return len(self.db_collection) > 0
+
+    def should_nag(self) -> bool:
+        # Find delta between opted-in collections and module collections;
+        # nag only if module has a collection which is not in db, and nag == True.
+
+        # We currently do not nag if the user is opted-out (or never opted-in).
+        # If we wish to do this in the future, we need to have a tri-mode state
+        # (opted in, opted out, no action yet), and it needs to be guarded by a
+        # config option (so that nagging can be turned off via config).
+        # We also need to add a last_opted_out_ceph_version variable, for the
+        # major upgrade check.
+
+        # check if there are collections the user is not opt-in to
+        # that we should nag about
+        for c in MODULE_COLLECTION:
+            for k, v in c.items():
+                if k == 'name' and v.name not in self.db_collection:
+                    if c['nag'] == True:
+                        self.log.debug(f"The collection: {v} is not reported, and we should nag about it")
+                        return True
+
+        # user might be opted-in to the most recent collection, or there is no
+        # new collection which requires nagging about
+        return self.is_major_upgrade()
+
+    def init_collection(self) -> None:
+        # We fetch from db the collections the user had already opted-in to.
+        # During the transition the results will be empty, but the user might 
+        # be opted-in to an older version (e.g. revision = 3)
+
+        collection = self.get_store('collection')
+
+        if collection is not None:
+            self.db_collection = json.loads(collection)
+
+        if self.db_collection is None:
+            # happens once on upgrade
+            if not self.enabled:
+                # user is not opted-in
+                self.set_store('collection', json.dumps([]))
+                self.log.debug("user is not opted-in")
+            else:
+                # user is opted-in, verify the revision:
+                if self.last_opt_revision == REVISION:
+                    self.log.debug(f"telemetry revision is {REVISION}")
+                    legacy_collection = [Collection.legacy_basic.name, Collection.legacy_device.name, Collection.legacy_crash.name, Collection.legacy_ident.name]
+                    self.set_store('collection', json.dumps(legacy_collection))
+                else:
+                    # user is opted-in to an older version, meaning they need
+                    # to re-opt in regardless
+                    self.set_store('collection', json.dumps([]))
+                    self.log.debug(f"user is opted-in but revision is old ({self.last_opt_revision}), needs to re-opt-in")
+
+            # reload collection after setting
+            collection = self.get_store('collection')
+            self.db_collection = json.loads(collection)
+        else:
+            # user has already upgraded
+            self.log.debug(f"user has upgraded already: collection: {self.db_collection}")
+
+    def is_enabled_collection(self, collection: Collection) -> bool:
+        return collection.name in self.db_collection
+
+    def set_collection(self) -> None:
+        """
+        Opt-in to collection; Update db with the currently available collections in the module
+        """
+        for c in MODULE_COLLECTION:
+            for k, v in c.items():
+                if k == 'name' and v.name not in self.db_collection:
+                    self.db_collection.append(v.name)
+
+        self.set_store('collection', json.dumps(self.db_collection))
 
     def send(self,
              report: Dict[str, Dict[str, str]],
@@ -1058,67 +1260,13 @@ class Module(MgrModule):
             return 1, '', '\n'.join(success + failed)
         return 0, '', '\n'.join(success)
 
-    @CLIReadCommand('telemetry status')
-    def status(self) -> Tuple[int, str, str]:
-        '''
-        Show current configuration
-        '''
-        r = {}
-        for opt in self.MODULE_OPTIONS:
-            r[opt['name']] = getattr(self, opt['name'])
-        r['last_upload'] = (time.ctime(self.last_upload)
-                            if self.last_upload else self.last_upload)
-        return 0, json.dumps(r, indent=4, sort_keys=True), ''
-
-    @CLICommand('telemetry on')
-    def on(self, license: Optional[str] = None) -> Tuple[int, str, str]:
-        '''
-        Enable telemetry reports from this cluster
-        '''
-        if license != LICENSE:
-            return -errno.EPERM, '', f'''Telemetry data is licensed under the {LICENSE_NAME} ({LICENSE_URL}).
-To enable, add '--license {LICENSE}' to the 'ceph telemetry on' command.'''
-        else:
-            self.set_module_option('enabled', True)
-            self.set_module_option('last_opt_revision', REVISION)
-            return 0, '', ''
-
-    @CLICommand('telemetry off')
-    def off(self) -> Tuple[int, str, str]:
-        '''
-        Disable telemetry reports from this cluster
-        '''
-        self.set_module_option('enabled', False)
-        self.set_module_option('last_opt_revision', 1)
-        return 0, '', ''
-
-    @CLICommand('telemetry send')
-    def do_send(self,
-                endpoint: Optional[List[EndPoint]] = None,
-                license: Optional[str] = None) -> Tuple[int, str, str]:
-        if self.last_opt_revision < LAST_REVISION_RE_OPT_IN and license != LICENSE:
-            self.log.debug(('A telemetry send attempt while opted-out. '
-                            'Asking for license agreement'))
-            return -errno.EPERM, '', f'''Telemetry data is licensed under the {LICENSE_NAME} ({LICENSE_URL}).
-To manually send telemetry data, add '--license {LICENSE}' to the 'ceph telemetry send' command.
-Please consider enabling the telemetry module with 'ceph telemetry on'.'''
-        else:
-            self.last_report = self.compile_report()
-            return self.send(self.last_report, endpoint)
-
-    @CLIReadCommand('telemetry show')
-    def show(self, channels: Optional[List[str]] = None) -> Tuple[int, str, str]:
-        '''
-        Show report of all channels
-        '''
-        report = self.get_report(channels=channels)
-
+    def format_perf_histogram(self, report):
         # Formatting the perf histograms so they are human-readable. This will change the
         # ranges and values, which are currently in list form, into strings so that
         # they are displayed horizontally instead of vertically.
         try:
             # Formatting ranges and values in osd_perf_histograms
-            modes_to_be_formatted = ['osd_perf_histograms']
+            modes_to_be_formatted = ['osd_perf_histograms_aggregated', 'osd_perf_histograms_separated']
             for mode in modes_to_be_formatted:
                 for config in report[mode]:
                     for histogram in config:
@@ -1141,6 +1289,144 @@ Please consider enabling the telemetry module with 'ceph telemetry on'.'''
             # histograms.
             pass
 
+
+    @CLIReadCommand('telemetry status')
+    def status(self) -> Tuple[int, str, str]:
+        '''
+        Show current configuration
+        '''
+        r = {}
+        for opt in self.MODULE_OPTIONS:
+            r[opt['name']] = getattr(self, opt['name'])
+        r['last_upload'] = (time.ctime(self.last_upload)
+                            if self.last_upload else self.last_upload)
+        return 0, json.dumps(r, indent=4, sort_keys=True), ''
+
+    @CLIReadCommand('telemetry diff')
+    def diff(self) -> Tuple[int, str, str]:
+        '''
+        Show the diff between opted-in collection and available collection
+        '''
+        diff = []
+        keys = ['nag']
+
+        for c in MODULE_COLLECTION:
+            for k, v in c.items():
+                if k == 'name':
+                    if not self.is_enabled_collection(v):
+                        diff.append({key: val for key, val in c.items() if key not in keys})
+
+        r = None
+        if diff == []:
+            r = "Telemetry is up to date"
+        else:
+            r = json.dumps(diff, indent=4, sort_keys=True)
+
+        return 0, r, ''
+
+    @CLICommand('telemetry on')
+    def on(self, license: Optional[str] = None) -> Tuple[int, str, str]:
+        '''
+        Enable telemetry reports from this cluster
+        '''
+        if license != LICENSE:
+            return -errno.EPERM, '', f'''Telemetry data is licensed under the {LICENSE_NAME} ({LICENSE_URL}).
+To enable, add '--license {LICENSE}' to the 'ceph telemetry on' command.'''
+        else:
+            self.set_module_option('enabled', True)
+            self.set_collection()
+
+            # for major releases upgrade nagging
+            mon_map = self.get('mon_map')
+            mon_min = mon_map.get("min_mon_release", 0)
+            self.set_store('last_opted_in_ceph_version', str(mon_min))
+            self.last_opted_in_ceph_version = mon_min
+
+            return 0, '', ''
+
+    @CLICommand('telemetry off')
+    def off(self) -> Tuple[int, str, str]:
+        '''
+        Disable telemetry reports from this cluster
+        '''
+        self.set_module_option('enabled', False)
+        self.set_store('collection', json.dumps([]))
+        self.db_collection = []
+
+        # we might need this info in the future, in case
+        # of nagging when user is opted-out
+        mon_map = self.get('mon_map')
+        mon_min = mon_map.get("min_mon_release", 0)
+        self.set_store('last_opted_out_ceph_version', str(mon_min))
+        self.last_opted_out_ceph_version = mon_min
+        
+        return 0, '', ''
+
+    @CLICommand('telemetry send')
+    def do_send(self,
+                endpoint: Optional[List[EndPoint]] = None,
+                license: Optional[str] = None) -> Tuple[int, str, str]:
+        if not self.is_opted_in() and license != LICENSE:
+            self.log.debug(('A telemetry send attempt while opted-out. '
+                            'Asking for license agreement'))
+            return -errno.EPERM, '', f'''Telemetry data is licensed under the {LICENSE_NAME} ({LICENSE_URL}).
+To manually send telemetry data, add '--license {LICENSE}' to the 'ceph telemetry send' command.
+Please consider enabling the telemetry module with 'ceph telemetry on'.'''
+        else:
+            self.last_report = self.compile_report()
+            return self.send(self.last_report, endpoint)
+
+    @CLIReadCommand('telemetry show')
+    def show(self, channels: Optional[List[str]] = None) -> Tuple[int, str, str]:
+        '''
+        Show a sample report of all enabled channels (except for 'device' channel)
+        '''
+        if not self.enabled:
+            # if telemetry is off, no report is being sent, hence nothing to show
+            msg = 'Telemetry is off. Please consider opting-in with `ceph telemetry on`.\n' \
+                  'Preview sample reports with `ceph telemetry preview`.'
+            return 0, msg, ''
+
+        report = self.get_report_locked(channels=channels)
+        self.format_perf_histogram(report)
+        report = json.dumps(report, indent=4, sort_keys=True)
+
+        if self.channel_device:
+            report += '''\nDevice report is generated separately. To see it run 'ceph telemetry show-device'.'''
+
+        return 0, report, ''
+
+    @CLIReadCommand('telemetry preview')
+    def preview(self, channels: Optional[List[str]] = None) -> Tuple[int, str, str]:
+        '''
+        Preview a sample report of the most recent collections available
+        '''
+        report = {}
+
+        # We use a lock to prevent a scenario where the user wishes to preview
+        # the report, and at the same time the module hits the interval of
+        # sending a report with the opted-in collection, which has less data
+        # than in the preview report.
+        with self.get_report_lock:
+            if len(self.collection_delta()) == 0:
+                # user is already opted-in to the most recent collection
+                msg = 'Telemetry is up to date, see report with `ceph telemetry show`'
+                return 0, msg, ''
+            else:
+                # there are collections the user is not opted-in to
+                next_collection = []
+
+                for c in MODULE_COLLECTION:
+                    for k, v in c.items():
+                        if k == 'name':
+                            next_collection.append(v.name)
+
+                opted_in_collection = self.db_collection
+                self.db_collection = next_collection
+                report = self.get_report(channels=channels)
+                self.db_collection = opted_in_collection
+
+        self.format_perf_histogram(report)
         report = json.dumps(report, indent=4, sort_keys=True)
         if self.channel_device:
             report += '''
@@ -1150,11 +1436,20 @@ Device report is generated separately. To see it run 'ceph telemetry show-device
 
     @CLIReadCommand('telemetry show-device')
     def show_device(self) -> Tuple[int, str, str]:
-        return 0, json.dumps(self.get_report('device'), indent=4, sort_keys=True), ''
+        return 0, json.dumps(self.get_report_locked('device'), indent=4, sort_keys=True), ''
 
     @CLIReadCommand('telemetry show-all')
     def show_all(self) -> Tuple[int, str, str]:
-        return 0, json.dumps(self.get_report('all'), indent=4, sort_keys=True), ''
+        return 0, json.dumps(self.get_report_locked('all'), indent=4, sort_keys=True), ''
+
+    def get_report_locked(self,
+                          report_type: str = 'default',
+                          channels: Optional[List[str]] = None) -> Dict[str, Any]:
+        '''
+        A wrapper around get_report to allow for compiling a report of the most recent module collections
+        '''
+        with self.get_report_lock:
+            return self.get_report(report_type, channels)
 
     def get_report(self,
                    report_type: str = 'default',
@@ -1182,12 +1477,13 @@ Device report is generated separately. To see it run 'ceph telemetry show-device
 
     def refresh_health_checks(self) -> None:
         health_checks = {}
-        if self.enabled and self.last_opt_revision < LAST_REVISION_RE_OPT_IN:
+        # TODO do we want to nag also in case the user is not opted-in?
+        if self.enabled and self.should_nag():
             health_checks['TELEMETRY_CHANGED'] = {
                 'severity': 'warning',
                 'summary': 'Telemetry requires re-opt-in',
                 'detail': [
-                    'telemetry report includes new information; must re-opt-in (or out)'
+                    'telemetry module includes new collections; please re-opt-in to new collections with `ceph telemetry on`'
                 ]
             }
         self.set_health_checks(health_checks)
@@ -1204,7 +1500,7 @@ Device report is generated separately. To see it run 'ceph telemetry show-device
 
             self.refresh_health_checks()
 
-            if self.last_opt_revision < LAST_REVISION_RE_OPT_IN:
+            if not self.is_opted_in():
                 self.log.debug('Not sending report until user re-opts-in')
                 self.event.wait(1800)
                 continue
@@ -1222,9 +1518,11 @@ Device report is generated separately. To see it run 'ceph telemetry show-device
                 try:
                     self.last_report = self.compile_report()
                 except Exception:
+                    # TODO add the exception here
                     self.log.exception('Exception while compiling report:')
 
                 self.send(self.last_report)
+                self.log.debug("SENDING REPORT")
             else:
                 self.log.debug('Interval for sending new report has not expired')
 

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -1436,12 +1436,26 @@ To enable, add '--license {LICENSE}' to the 'ceph telemetry on' command.'''
         msg = 'Telemetry is now disabled.'
         return 0, msg, ''
 
+    @CLIReadCommand('telemetry enable channel all')
+    def enable_channel_all(self, channels: List[str] = ALL_CHANNELS) -> Tuple[int, str, str]:
+        '''
+        Enable all channels
+        '''
+        return self.toggle_channel('enable', channels)
+
     @CLIReadCommand('telemetry enable channel')
     def enable_channel(self, channels: Optional[List[str]] = None) -> Tuple[int, str, str]:
         '''
         Enable a list of channels
         '''
         return self.toggle_channel('enable', channels)
+
+    @CLIReadCommand('telemetry disable channel all')
+    def disable_channel_all(self, channels: List[str] = ALL_CHANNELS) -> Tuple[int, str, str]:
+        '''
+        Disable all channels
+        '''
+        return self.toggle_channel('disable', channels)
 
     @CLIReadCommand('telemetry disable channel')
     def disable_channel(self, channels: Optional[List[str]] = None) -> Tuple[int, str, str]:

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -15,6 +15,7 @@ import requests
 import uuid
 import time
 from datetime import datetime, timedelta
+from prettytable import PrettyTable
 from threading import Event, Lock
 from collections import defaultdict
 from typing import cast, Any, DefaultDict, Dict, List, Optional, Tuple, TypeVar, TYPE_CHECKING, Union
@@ -1436,6 +1437,39 @@ To enable, add '--license {LICENSE}' to the 'ceph telemetry on' command.'''
         Disable a list of channels
         '''
         return self.toggle_channel('disable', channels)
+
+    @CLIReadCommand('telemetry channel ls')
+    def channel_ls(self) -> Tuple[int, str, str]:
+        '''
+        List all channels
+        '''
+        table = PrettyTable(
+            [
+                'NAME', 'ENABLED', 'DEFAULT', 'DESC',
+            ],
+            border=False)
+        table.align['NAME'] = 'l'
+        table.align['ENABLED'] = 'l'
+        table.align['DEFAULT'] = 'l'
+        table.align['DESC'] = 'l'
+        table.left_padding_width = 0
+        table.right_padding_width = 4
+
+        for c in ALL_CHANNELS:
+            enabled = "ON" if getattr(self, f"channel_{c}") else "OFF"
+            for o in self.MODULE_OPTIONS:
+                if o['name'] == f"channel_{c}":
+                    default = "ON" if o.get('default', None) else "OFF"
+                    desc = o.get('desc', None)
+
+            table.add_row((
+                c,
+                enabled,
+                default,
+                desc,
+            ))
+
+        return 0, table.get_string(), ''
 
     @CLICommand('telemetry send')
     def do_send(self,

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -1178,8 +1178,15 @@ class Module(MgrModule):
                         return True
 
         # user might be opted-in to the most recent collection, or there is no
-        # new collection which requires nagging about
-        return self.is_major_upgrade()
+        # new collection which requires nagging about; thus nag in case it's a
+        # major upgrade and there are new collections
+        # (which their own nag == False):
+        new_collections = False
+        col_delta = self.collection_delta()
+        if col_delta is not None and len(col_delta) > 0:
+            new_collections = True
+
+        return self.is_major_upgrade() and new_collections
 
     def init_collection(self) -> None:
         # We fetch from db the collections the user had already opted-in to.

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -1071,7 +1071,7 @@ class Module(MgrModule):
             report['crashes'] = self.gather_crashinfo()
 
         if 'perf' in channels:
-            if self.is_enabled_collection(Collection.perf):
+            if self.is_enabled_collection(Collection.perf_perf):
                 report['perf_counters'] = self.gather_perf_counters('separated')
                 report['stats_per_pool'] = self.get_stats_per_pool()
                 report['stats_per_pg'] = self.get_stats_per_pg()
@@ -1124,10 +1124,9 @@ class Module(MgrModule):
         new_collection : List[Collection] = []
 
         for c in MODULE_COLLECTION:
-            for k, v in c.items():
-                if k == 'name' and v.name not in self.db_collection:
-                    if c['channel'] in channels:
-                        new_collection.append(v)
+            if c['name'].name not in self.db_collection:
+                if c['channel'] in channels:
+                    new_collection.append(c['name'])
 
         return new_collection
 
@@ -1173,11 +1172,10 @@ class Module(MgrModule):
         # that we should nag about
         if self.db_collection is not None:
             for c in MODULE_COLLECTION:
-                for k, v in c.items():
-                    if k == 'name' and v.name not in self.db_collection:
-                        if c['nag'] == True:
-                            self.log.debug(f"The collection: {v} is not reported, and we should nag about it")
-                            return True
+                if c['name'].name not in self.db_collection:
+                    if c['nag'] == True:
+                        self.log.debug(f"The collection: {c['name']} is not reported")
+                        return True
 
         # user might be opted-in to the most recent collection, or there is no
         # new collection which requires nagging about
@@ -1234,9 +1232,8 @@ class Module(MgrModule):
             raise RuntimeError('db_collection is None after initial setting')
 
         for c in MODULE_COLLECTION:
-            for k, v in c.items():
-                if k == 'name' and v.name not in self.db_collection:
-                    self.db_collection.append(v.name)
+            if c['name'].name not in self.db_collection:
+                self.db_collection.append(c['name'])
 
         self.set_store('collection', json.dumps(self.db_collection))
 
@@ -1371,10 +1368,8 @@ class Module(MgrModule):
         keys = ['nag']
 
         for c in MODULE_COLLECTION:
-            for k, v in c.items():
-                if k == 'name':
-                    if not self.is_enabled_collection(Collection(v)):
-                        diff.append({key: val for key, val in c.items() if key not in keys})
+            if not self.is_enabled_collection(c['name']):
+                diff.append({key: val for key, val in c.items() if key not in keys})
 
         r = None
         if diff == []:
@@ -1593,9 +1588,7 @@ Please consider enabling the telemetry module with 'ceph telemetry on'.'''
                 next_collection = []
 
                 for c in MODULE_COLLECTION:
-                    for k, v in c.items():
-                        if k == 'name':
-                            next_collection.append(v.name)
+                    next_collection.append(c['name'].name)
 
                 opted_in_collection = self.db_collection
                 self.db_collection = next_collection
@@ -1649,9 +1642,7 @@ Please consider enabling the telemetry module with 'ceph telemetry on'.'''
             next_collection = []
 
             for c in MODULE_COLLECTION:
-                for k, v in c.items():
-                    if k == 'name':
-                        next_collection.append(v.name)
+                next_collection.append(c['name'].name)
 
             opted_in_collection = self.db_collection
             self.db_collection = next_collection
@@ -1697,9 +1688,7 @@ Please consider enabling the telemetry module with 'ceph telemetry on'.'''
             next_collection = []
 
             for c in MODULE_COLLECTION:
-                for k, v in c.items():
-                    if k == 'name':
-                        next_collection.append(v.name)
+                next_collection.append(c['name'].name)
 
             opted_in_collection = self.db_collection
             self.db_collection = next_collection

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -1493,41 +1493,57 @@ To enable, add '--license {LICENSE}' to the 'ceph telemetry on' command.'''
         '''
         List all collections
         '''
+        col_delta = self.collection_delta()
+        msg = ''
+        if col_delta is not None and len(col_delta) > 0:
+            msg = f"New collections are available:\n" \
+                  f"{sorted([c.name for c in col_delta])}\n" \
+                  f"Run `ceph telemetry on` to opt-in to these collections.\n"
+
         table = PrettyTable(
             [
-                'NAME', 'ENROLLED', 'STATUS', 'DEFAULT', 'DESC',
+                'NAME', 'STATUS', 'DESC',
             ],
             border=False)
         table.align['NAME'] = 'l'
-        table.align['ENROLLED'] = 'l'
         table.align['STATUS'] = 'l'
-        table.align['DEFAULT'] = 'l'
         table.align['DESC'] = 'l'
         table.left_padding_width = 0
         table.right_padding_width = 4
 
         for c in MODULE_COLLECTION:
             name = c['name']
-            enrolled = "TRUE" if self.is_enabled_collection(name) else "FALSE"
-            status = "ON" if getattr(self, f"channel_{c['channel']}") and self.is_enabled_collection(name) \
-                    else "OFF"
-            # default value of *channel*, since we check for active channels
-            # when generating reports
-            for o in self.MODULE_OPTIONS:
-                if o['name'] == f"channel_{c['channel']}":
-                    default = "ON" if o.get('default', None) else "OFF"
+            opted_in = self.is_enabled_collection(name)
+            channel_enabled = getattr(self, f"channel_{c['channel']}")
+
+            status = ''
+            if channel_enabled and opted_in:
+                status = "REPORTING"
+            else:
+                why = ''
+                delimiter = ''
+
+                if not opted_in:
+                    why += "NOT OPTED-IN"
+                    delimiter = ', '
+                if not channel_enabled:
+                    why += f"{delimiter}CHANNEL {c['channel']} IS OFF"
+
+                status = f"NOT REPORTING: {why}"
 
             desc = c['description']
 
             table.add_row((
                 name,
-                enrolled,
                 status,
-                default,
                 desc,
             ))
 
-        return 0, table.get_string(sortby="NAME"), ''
+        if len(msg):
+            # add a new line between message and table output
+            msg = f"{msg} \n"
+
+        return 0, f'{msg}{table.get_string(sortby="NAME")}', ''
 
     @CLICommand('telemetry send')
     def do_send(self,

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -1345,15 +1345,6 @@ class Module(MgrModule):
 
         return 0, msg, ''
 
-    def restore_default_opt_setting(self, opt_name: str) -> None:
-        for o in self.MODULE_OPTIONS:
-            if o['name'] == opt_name:
-                default_val = o.get('default', None)
-                self.set_module_option(opt_name, default_val)
-                setattr(self,
-                        opt_name,
-                        default_val)
-
     @CLIReadCommand('telemetry status')
     def status(self) -> Tuple[int, str, str]:
         '''
@@ -1442,10 +1433,7 @@ To enable, add '--license {LICENSE}' to the 'ceph telemetry on' command.'''
         self.set_store('last_opted_out_ceph_version', str(mon_min))
         self.last_opted_out_ceph_version = mon_min
 
-        for c in ALL_CHANNELS:
-            self.restore_default_opt_setting(f"channel_{c}")
-
-        msg = 'Telemetry is now disabled. Channels settings are restored to default.'
+        msg = 'Telemetry is now disabled.'
         return 0, msg, ''
 
     @CLIReadCommand('telemetry enable channel')

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -1144,7 +1144,7 @@ class Module(MgrModule):
         mon_min = mon_map.get("min_mon_release", 0)
 
         if mon_min - self.last_opted_in_ceph_version > 0:
-            self.log.debug(f"major upgrade: mon_min is is: {mon_min} and user last opted-in in {self.last_opted_in_ceph_version}")
+            self.log.debug(f"major upgrade: mon_min is: {mon_min} and user last opted-in in {self.last_opted_in_ceph_version}")
             return True
 
         return False

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -1289,6 +1289,34 @@ class Module(MgrModule):
             # histograms.
             pass
 
+    def toggle_channel(self, action, channels: Optional[List[str]] = None) -> Tuple[int, str, str]:
+        '''
+        Enable or disable a list of channels
+        '''
+        if not self.enabled:
+            # telemetry should be on for channels to be toggled
+            msg = 'Telemetry is off. Please consider opting-in with `ceph telemetry on`.\n' \
+                  'Preview sample reports with `ceph telemetry preview`.'
+            return 0, msg, ''
+
+        if channels is None:
+            msg = f'Please provide a channel name. Available channels: {ALL_CHANNELS}.'
+            return 0, msg, ''
+
+        state = action == 'enable'
+        msg = ''
+        for c in channels:
+            if c not in ALL_CHANNELS:
+                msg = f"{msg}{c} is not a valid channel name. "\
+                        f"Available channels: {ALL_CHANNELS}.\n"
+            else:
+                self.set_module_option(f"channel_{c}", state)
+                setattr(self,
+                        f"channel_{c}",
+                        state)
+                msg = f"{msg}channel_{c} is {action}d\n"
+
+        return 0, msg, ''
 
     @CLIReadCommand('telemetry status')
     def status(self) -> Tuple[int, str, str]:
@@ -1361,6 +1389,20 @@ To enable, add '--license {LICENSE}' to the 'ceph telemetry on' command.'''
         self.last_opted_out_ceph_version = mon_min
 
         return 0, '', ''
+
+    @CLIReadCommand('telemetry enable channel')
+    def enable_channel(self, channels: Optional[List[str]] = None) -> Tuple[int, str, str]:
+        '''
+        Enable a list of channels
+        '''
+        return self.toggle_channel('enable', channels)
+
+    @CLIReadCommand('telemetry disable channel')
+    def disable_channel(self, channels: Optional[List[str]] = None) -> Tuple[int, str, str]:
+        '''
+        Disable a list of channels
+        '''
+        return self.toggle_channel('disable', channels)
 
     @CLICommand('telemetry send')
     def do_send(self,

--- a/src/pybind/mgr/telemetry/tests/test_telemetry.py
+++ b/src/pybind/mgr/telemetry/tests/test_telemetry.py
@@ -1,0 +1,121 @@
+import json
+import pytest
+import unittest
+from unittest import mock
+
+import telemetry
+from typing import cast, Any, DefaultDict, Dict, List, Optional, Tuple, TypeVar, TYPE_CHECKING, Union
+
+OptionValue = Optional[Union[bool, int, float, str]]
+
+Collection = telemetry.module.Collection
+ALL_CHANNELS = telemetry.module.ALL_CHANNELS
+MODULE_COLLECTION = telemetry.module.MODULE_COLLECTION
+
+COLLECTION_BASE = ["basic_base", "device_base", "crash_base", "ident_base"]
+
+class TestTelemetry:
+    @pytest.mark.parametrize("preconfig,postconfig,prestore,poststore,expected",
+            [
+                (
+                    # user is not opted-in
+                    {
+                        'last_opt_revision': 1,
+                        'enabled': False,
+                    },
+                    {
+                        'last_opt_revision': 1,
+                        'enabled': False,
+                    },
+                    {
+                        # None
+                    },
+                    {
+                        'collection': []
+                    },
+                    {
+                        'is_opted_in': False,
+                        'is_enabled_collection':
+                        {
+                            'basic_base': False,
+                            'basic_mds_metadata': False,
+                        },
+                    },
+                ),
+                (
+                    # user is opted-in to an old revision
+                    {
+                        'last_opt_revision': 2,
+                        'enabled': True,
+                    },
+                    {
+                        'last_opt_revision': 2,
+                        'enabled': True,
+                    },
+                    {
+                        # None
+                    },
+                    {
+                        'collection': []
+                    },
+                    {
+                        'is_opted_in': False,
+                        'is_enabled_collection':
+                        {
+                            'basic_base': False,
+                            'basic_mds_metadata': False,
+                        },
+                    },
+                ),
+                (
+                    # user is opted-in to the latest revision
+                    {
+                        'last_opt_revision': 3,
+                        'enabled': True,
+                    },
+                    {
+                        'last_opt_revision': 3,
+                        'enabled': True,
+                    },
+                    {
+                        # None
+                    },
+                    {
+                        'collection': COLLECTION_BASE
+                    },
+                    {
+                        'is_opted_in': True,
+                        'is_enabled_collection':
+                        {
+                            'basic_base': True,
+                            'basic_mds_metadata': False,
+                        },
+                    },
+                ),
+            ])
+    def test_upgrade(self,
+                preconfig: Dict[str, Any], \
+                postconfig: Dict[str, Any], \
+                prestore: Dict[str, Any], \
+                poststore: Dict[str, Any], \
+                expected: Dict[str, Any]) -> None:
+
+        m = telemetry.Module('telemetry', '', '')
+
+        if preconfig is not None:
+            for k, v in preconfig.items():
+                # no need to mock.patch since _ceph_set_module_option() which
+                # is called from set_module_option() is already mocked for
+                # tests, and provides setting default values for all module
+                # options
+                m.set_module_option(k, v)
+
+        m.config_update_module_option()
+        m.load()
+
+        collection = json.loads(m.get_store('collection'))
+
+        assert collection == poststore['collection']
+        assert m.is_opted_in() == expected['is_opted_in']
+        assert m.is_enabled_collection(Collection.basic_base) == expected['is_enabled_collection']['basic_base']
+        assert m.is_enabled_collection(Collection.basic_mds_metadata) == expected['is_enabled_collection']['basic_mds_metadata']

--- a/src/pybind/mgr/telemetry/tox.ini
+++ b/src/pybind/mgr/telemetry/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist =
+    py3
+    mypy
+skipsdist = true
+
+[testenv]
+deps =
+    mock
+    pytest
+commands =
+    pytest {posargs}


### PR DESCRIPTION
We only need to format one mode now: `osd_perf_histograms`.

Signed-off-by: Laura Flores <lflores@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
